### PR TITLE
Deferred unnecessary import

### DIFF
--- a/Skimage_numpy/source/skimage/_shared/_geometry.py
+++ b/Skimage_numpy/source/skimage/_shared/_geometry.py
@@ -1,7 +1,6 @@
 __all__ = ['polygon_clip', 'polygon_area']
 
 import numpy as np
-from matplotlib import _path, path, transforms
 
 
 def polygon_clip(rp, cp, r0, c0, r1, c1):
@@ -25,6 +24,8 @@ def polygon_clip(rp, cp, r0, c0, r1, c1):
     AGG 2.4 and exposed in Matplotlib.
 
     """
+    from matplotlib import _path, path, transforms
+    
     poly = path.Path(np.vstack((rp, cp)).T, closed=True)
     clip_rect = transforms.Bbox([[r0, c0], [r1, c1]])
     poly_clipped = poly.clip_to_bbox(clip_rect).to_polygons()[0]


### PR DESCRIPTION
This change just tracks master:

https://github.com/scikit-image/scikit-image/commit/86c7184d247ef8f6d55d2fe32ed19e0aa6b32fdb

By deferring the import, we spare ourselves the need to install matplotlib!