### PR TITLE
AWS Lambda has limit timeout for 300s

### DIFF
--- a/Tensorflow/source/serverless.yml
+++ b/Tensorflow/source/serverless.yml
@@ -6,7 +6,7 @@ provider:
   name: aws
   runtime: python2.7
   memorySize: 1536
-  timeout: 600
+  timeout: 300
 
 functions:
   main:


### PR DESCRIPTION
This settings will cause Exception on serverless commands when deploy to lambda.

like this:

```
Serverless: Operation failed!

  Serverless Error ---------------------------------------

  An error occurred: MainLambdaFunction - 1 validation error detected: Value '600' at 'timeout' failed to satisfy constraint: Member must have value less than or equal to 300.
```