### PR TITLE
Add Pytorch 1.0.1 for python3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,3 +300,28 @@ AWS Lambda pack in Python for processing satellite imagery. Basically it enables
 - Pyproj (https://github.com/jswhit/pyproj)
 - Shapely (https://github.com/Toblerity/Shapely)
 - PIL (https://pillow.readthedocs.io/)
+
+---
+
+### PyTorch
+
+Python 3.6 based PyTorch
+
+#### Tools
+
+- PyTorch 1.0.1 (CPU)
+- torchvision 0.2.1
+
+#### Installed Packages (deps)
+
+- numpy-1.16.1 
+- pillow-5.4.1 
+- six-1.12.0 
+- torchvision-0.2.1
+
+#### Build Pack
+
+```bash
+# You need `docker` before run
+./build-with-docker.sh
+```

--- a/pytorch/build-with-docker.sh
+++ b/pytorch/build-with-docker.sh
@@ -1,0 +1,4 @@
+docker pull amazonlinux:1
+docker run -v $(pwd):/outputs --name lambdapackgen-pytorch -d amazonlinux:1 tail -f /dev/null
+docker exec -i -t lambdapackgen-pytorch /bin/bash /outputs/buildPack_py3.sh
+

--- a/pytorch/buildPack_py3.sh
+++ b/pytorch/buildPack_py3.sh
@@ -1,0 +1,69 @@
+dev_install () {
+    yum -y update
+    yum -y upgrade
+    yum install -y \
+    wget \
+    gcc \
+    gcc-c++ \
+    python36-devel \
+    python36-virtualenv \
+    python36-pip \
+    findutils \
+    zlib-devel \
+    zip
+}
+
+pip_rasterio () {
+    cd /home/
+    rm -rf env
+    python3 -m virtualenv env --python=python3
+    source env/bin/activate
+    pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp36-cp36m-linux_x86_64.whl
+    pip3 install torchvision
+    deactivate
+}
+
+
+gather_pack () {
+    # packing
+    cd /home/
+    source env/bin/activate
+
+    rm -rf lambdapack
+    mkdir lambdapack
+    cd lambdapack
+
+    cp -R /home/env/lib/python3.6/site-packages/* .
+    cp -R /home/env/lib64/python3.6/site-packages/* .
+    echo "original size $(du -sh /home/lambdapack | cut -f1)"
+
+    # cleaning libs
+    rm -rf external
+    find . -type d -name "tests" -exec rm -rf {} +
+
+    # cleaning
+    find -name "*.so" | xargs strip
+    find -name "*.so.*" | xargs strip
+    # find . -name tests -type d -print0|xargs -0 rm -r --
+    # find . -name test -type d -print0|xargs -0 rm -r --    
+    rm -r pip
+    rm -r pip-*
+    rm -r wheel
+    rm -r wheel-*
+    rm easy_install.py
+    find . -name \*.pyc -delete
+    # find . -name \*.txt -delete
+    echo "stripped size $(du -sh /home/lambdapack | cut -f1)"
+
+    # compressing
+    zip -FS -r9 /outputs/pack.zip * > /dev/null
+    echo "compressed size $(du -sh /outputs/pack.zip | cut -f1)"
+}
+
+main () {
+    dev_install
+    pip_rasterio
+    gather_pack
+}
+
+main


### PR DESCRIPTION
Add Pytorch for python3.6

# Tools

- PyTorch 1.0.1 (CPU)
- torchvision 0.2.1

# Installed Packages (deps)

- numpy-1.16.1 
- pillow-5.4.1 
- six-1.12.0 
- torchvision-0.2.1